### PR TITLE
#8 - allows for multiple connections / async and agnostic module loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,47 @@ Please note that if you use the legacy cassandra 2.x compliant version then plea
 ## Usage
 
 
+**Asynchronously load schemas**
+```js
+var Cassandra = require('express-cassandra');
+var cassandra = Cassandra.createClient({
+    clientOptions: {
+        contactPoints: ['127.0.0.1'],
+        protocolOptions: { port: 9042 },
+        keyspace: 'mykeyspace',
+        queryOptions: {consistency: Cassandra.consistencies.one}
+    },
+    ormOptions: {
+        defaultReplicationStrategy : {
+            class: 'SimpleStrategy',
+            replication_factor: 1
+        },
+        dropTableOnSchemaChange: false,
+        createKeyspace: true
+    }
+});
+
+
+var UserSchema = cassandra.loadSchema('users', {
+    fields: {
+        name: 'text',
+        password: 'text'
+    },
+    key: ['name']
+});
+
+cassandra.connect(function (err) {
+    if (err) {
+        console.log(err.message);
+    } else {
+        console.log(cassandra.modelInstance.users);
+        console.log(cassandra.modelInstance.users === UserSchema);
+    }
+});
+
+```
+
+
 ```js
 var models = require('express-cassandra');
 

--- a/lib/expressCassandra.js
+++ b/lib/expressCassandra.js
@@ -15,13 +15,15 @@ class CassandraClient {
         return new CassandraClient(options);
     }
 
-    setDirectory(directory) {
-        this.directory = directory;
-        return this;
+    static setDirectory(directory) {
+        CassandraClient.directory = directory;
+        return CassandraClient;
     }
 
-    bind(options, cb) {
-        var self = CassandraClient.createClient(options);
+    static bind(options, cb) {
+        var self = CassandraClient;
+        self.modelInstance = {};
+        self.orm = new orm(options.clientOptions, options.ormOptions);
         self.orm.connect(function(err){
             if(err) {
                 if(cb) cb(err);
@@ -69,11 +71,8 @@ class CassandraClient {
                     else {
                         if(cb) cb();
                     }
-
                 });
-
             });
-
         });
     }
 
@@ -92,7 +91,7 @@ class CassandraClient {
         return self.modelInstance[modelName];
     }
 
-    timeuuid(date, maxOrMin) {
+    static timeuuid(date, maxOrMin) {
         var timeuuid;
         if(date) {
             if(date instanceof Date) {
@@ -119,14 +118,6 @@ class CassandraClient {
         return timeuuid.toString();
     }
 
-    maxTimeuuid(date) {
-        return this.timeuuid(date, "max");
-    }
-
-    minTimeuuid(date) {
-        return this.timeuuid(date, "min");
-    }
-
     static uuid() {
         var uuid = cql.types.Uuid.random();
         return uuid.toString();
@@ -151,12 +142,40 @@ class CassandraClient {
         });
     }
 
+    static doBatch(queries, callback) {
+        CassandraClient.prototype.doBatch.call(CassandraClient, queries, callback);
+    }
+
     static get consistencies() {
         return cql.types.consistencies;
     }
 
     static get datatypes() {
         return cql.types;
+    }
+
+    static maxTimeuuid(date) {
+        return CassandraClient.timeuuid(date, "max");
+    }
+
+    static minTimeuuid(date) {
+        return CassandraClient.timeuuid(date, "min");
+    }
+
+    static get instance() {
+        return CassandraClient.modelInstance;
+    }
+
+    static get close() {
+        return CassandraClient.orm.close;
+    }
+
+    maxTimeuuid(date) {
+        return this.timeuuid(date, "max");
+    }
+
+    minTimeuuid(date) {
+        return this.timeuuid(date, "min");
     }
 
     get instance() {
@@ -167,7 +186,7 @@ class CassandraClient {
         return this.orm.close;
     }
 
-    _translateFileNameToModelName (fileName) {
+    static _translateFileNameToModelName (fileName) {
         return fileName
             .slice(	0,
                     //Get everything before the last dot
@@ -178,7 +197,9 @@ class CassandraClient {
 
 CassandraClient.prototype.uuid = CassandraClient.uuid;
 CassandraClient.prototype.uuidFromString = CassandraClient.uuidFromString;
+CassandraClient.prototype.timeuuid = CassandraClient.timeuuid;
 CassandraClient.prototype.consistencies = CassandraClient.consistencies;
 CassandraClient.prototype.datatypes = CassandraClient.datatypes;
+CassandraClient.prototype._translateFileNameToModelName = CassandraClient._translateFileNameToModelName;
 
 module.exports = CassandraClient;

--- a/lib/expressCassandra.js
+++ b/lib/expressCassandra.js
@@ -1,22 +1,27 @@
+"use strict";
 var fs = require('fs');
-var _ = require('lodash');
 var async = require('async');
 var cql = require('cassandra-driver');
-
 var orm = require('./orm/apollo');
-
-module.exports = {
-
-    setDirectory : function(directory) {
-        this.directory = directory;
-        this.modelInstance = {};
-        return this;
-    },
-
-    bind : function(options, cb) {
+class CassandraClient {
+ 
+    constructor(options) {
         var self = this;
-
+        self.modelInstance = {};
         self.orm = new orm(options.clientOptions, options.ormOptions);
+    }
+
+    static createClient(options) {
+        return new CassandraClient(options);
+    }
+
+    setDirectory(directory) {
+        this.directory = directory;
+        return this;
+    }
+
+    bind(options, cb) {
+        var self = CassandraClient.createClient(options);
         self.orm.connect(function(err){
             if(err) {
                 if(cb) cb(err);
@@ -70,9 +75,24 @@ module.exports = {
             });
 
         });
-    },
+    }
 
-    timeuuid: function(date, maxOrMin) {
+    connect(callback) {
+        var self = this;
+        self.orm.connect(callback);
+    }
+
+    loadSchema (modelName, modelSchema, callback) {
+        var self = this;
+        self.modelInstance[modelName] = self.orm.add_model(
+            modelName.toLowerCase(),
+            modelSchema,
+            callback
+        );
+        return self.modelInstance[modelName];
+    }
+
+    timeuuid(date, maxOrMin) {
         var timeuuid;
         if(date) {
             if(date instanceof Date) {
@@ -97,26 +117,26 @@ module.exports = {
         }
 
         return timeuuid.toString();
-    },
+    }
 
-    maxTimeuuid: function(date) {
+    maxTimeuuid(date) {
         return this.timeuuid(date, "max");
-    },
+    }
 
-    minTimeuuid: function(date) {
+    minTimeuuid(date) {
         return this.timeuuid(date, "min");
-    },
+    }
 
-    uuid: function() {
+    static uuid() {
         var uuid = cql.types.Uuid.random();
         return uuid.toString();
-    },
+    }
 
-    uuidFromString: function(string) {
+    static uuidFromString(string) {
         return cql.types.Uuid.fromString(string);
-    },
+    }
 
-    doBatch: function(queries, callback) {
+    doBatch(queries, callback) {
         var randomModel = this.modelInstance[Object.keys(this.modelInstance)[0]];
         var builtQueries = [];
         for(var i=0;i<queries.length;i++) {
@@ -129,25 +149,25 @@ module.exports = {
             if(err) callback(err);
             else callback();
         });
-    },
+    }
+
+    static get consistencies() {
+        return cql.types.consistencies;
+    }
+
+    static get datatypes() {
+        return cql.types;
+    }
 
     get instance() {
         return this.modelInstance;
-    },
+    }
 
     get close() {
         return this.orm.close;
-    },
+    }
 
-    get consistencies() {
-        return cql.types.consistencies;
-    },
-
-    get datatypes() {
-        return cql.types;
-    },
-
-    _translateFileNameToModelName : function(fileName) {
+    _translateFileNameToModelName (fileName) {
         return fileName
             .slice(	0,
                     //Get everything before the last dot
@@ -155,3 +175,10 @@ module.exports = {
             .replace('Model', '');
     }
 };
+
+CassandraClient.prototype.uuid = CassandraClient.uuid;
+CassandraClient.prototype.uuidFromString = CassandraClient.uuidFromString;
+CassandraClient.prototype.consistencies = CassandraClient.consistencies;
+CassandraClient.prototype.datatypes = CassandraClient.datatypes;
+
+module.exports = CassandraClient;

--- a/lib/expressCassandra.js
+++ b/lib/expressCassandra.js
@@ -3,203 +3,225 @@ var fs = require('fs');
 var async = require('async');
 var cql = require('cassandra-driver');
 var orm = require('./orm/apollo');
-class CassandraClient {
- 
-    constructor(options) {
-        var self = this;
-        self.modelInstance = {};
-        self.orm = new orm(options.clientOptions, options.ormOptions);
-    }
+var CassandraClient = function (options) {
+    var self = this;
+    self.modelInstance = {};
+    self.orm = new orm(options.clientOptions, options.ormOptions);
+};
 
-    static createClient(options) {
-        return new CassandraClient(options);
-    }
+CassandraClient.createClient = function (options) {
+    return new CassandraClient(options);
+};
 
-    static setDirectory(directory) {
-        CassandraClient.directory = directory;
-        return CassandraClient;
-    }
+CassandraClient.setDirectory = function (directory) {
+    CassandraClient.directory = directory;
+    return CassandraClient;
+};
 
-    static bind(options, cb) {
-        var self = CassandraClient;
-        self.modelInstance = {};
-        self.orm = new orm(options.clientOptions, options.ormOptions);
-        self.orm.connect(function(err){
+CassandraClient.bind = function (options, cb) {
+    var self = CassandraClient;
+    self.modelInstance = {};
+    self.orm = new orm(options.clientOptions, options.ormOptions);
+    self.orm.connect(function(err){
+        if(err) {
+            if(cb) cb(err);
+            return;
+        }
+
+        fs.readdir(self.directory, function(err, list) {
             if(err) {
                 if(cb) cb(err);
                 return;
             }
 
-            fs.readdir(self.directory, function(err, list) {
-                if(err) {
-                    if(cb) cb(err);
+            async.each(list, function(file, callback) {
+
+                var fileName = self.directory + '/' + file;
+                if(fileName.indexOf('Model') == -1) {
+                    callback();
                     return;
                 }
 
-                async.each(list, function(file, callback) {
+                var modelName = self._translateFileNameToModelName(file);
 
-                    var fileName = self.directory + '/' + file;
-                    if(fileName.indexOf('Model') == -1) {
-                        callback();
-                        return;
-                    }
-
-                    var modelName = self._translateFileNameToModelName(file);
-
-                    if(modelName) {
-                        var modelSchema = require(fileName);
-                        self.modelInstance[modelName] = self.orm.add_model(
-                            modelName.toLowerCase(),
-                            modelSchema,
-                            function(err, result){
-                                if(err) {
-                                    callback(err);
-                                }
-                                else callback();
+                if(modelName) {
+                    var modelSchema = require(fileName);
+                    self.modelInstance[modelName] = self.orm.add_model(
+                        modelName.toLowerCase(),
+                        modelSchema,
+                        function(err, result){
+                            if(err) {
+                                callback(err);
                             }
+                            else callback();
+                        }
                         );
-                    }
-                    else {
-                        callback();
-                    }
+                }
+                else {
+                    callback();
+                }
 
-                }, function(err){
+            }, function(err){
 
-                    if(err) {
-                        if(cb) cb(err);
-                    }
-                    else {
-                        if(cb) cb();
-                    }
-                });
+                if(err) {
+                    if(cb) cb(err);
+                }
+                else {
+                    if(cb) cb();
+                }
             });
         });
-    }
+    });
+};
 
-    connect(callback) {
-        var self = this;
-        self.orm.connect(callback);
-    }
+CassandraClient.prototype.connect = function (callback) {
+    var self = this;
+    self.orm.connect(callback);
+};
 
-    loadSchema (modelName, modelSchema, callback) {
-        var self = this;
-        self.modelInstance[modelName] = self.orm.add_model(
+CassandraClient.prototype.loadSchema = function (modelName, modelSchema, callback) {
+    var self = this;
+    self.modelInstance[modelName] = self.orm.add_model(
             modelName.toLowerCase(),
             modelSchema,
             callback
-        );
-        return self.modelInstance[modelName];
-    }
+            );
+    return self.modelInstance[modelName];
+};
 
-    static timeuuid(date, maxOrMin) {
-        var timeuuid;
-        if(date) {
-            if(date instanceof Date) {
-                timeuuid = cql.types.TimeUuid.fromDate(date);
-            } else if(date instanceof String) {
-                timeuuid = cql.types.TimeUuid.fromString(date);
-            } else {
-                throw("Invalid date provided to timeuuid");
-            }
+CassandraClient.timeuuid = function (date, maxOrMin) {
+    var timeuuid;
+    if(date) {
+        if(date instanceof Date) {
+            timeuuid = cql.types.TimeUuid.fromDate(date);
+        } else if(date instanceof String) {
+            timeuuid = cql.types.TimeUuid.fromString(date);
         } else {
-            timeuuid = cql.types.TimeUuid.now();
+            throw("Invalid date provided to timeuuid");
         }
+    } else {
+        timeuuid = cql.types.TimeUuid.now();
+    }
 
-        if(maxOrMin) {
-            switch(maxOrMin.toLowerCase) {
-                case "min":
-                    timeuuid = timeuuid.min();
+    if(maxOrMin) {
+        switch(maxOrMin.toLowerCase) {
+            case "min":
+                timeuuid = timeuuid.min();
                 break;
-                case "max":
-                    timeuuid = timeuuid.max();
-            }
+            case "max":
+                timeuuid = timeuuid.max();
         }
-
-        return timeuuid.toString();
     }
 
-    static uuid() {
-        var uuid = cql.types.Uuid.random();
-        return uuid.toString();
-    }
+    return timeuuid.toString();
+};
 
-    static uuidFromString(string) {
-        return cql.types.Uuid.fromString(string);
-    }
+CassandraClient.uuid = function () {
+    var uuid = cql.types.Uuid.random();
+    return uuid.toString();
+};
 
-    doBatch(queries, callback) {
-        var randomModel = this.modelInstance[Object.keys(this.modelInstance)[0]];
-        var builtQueries = [];
-        for(var i=0;i<queries.length;i++) {
-            builtQueries.push({
-                query: queries[i],
-                params: []
-            });
-        }
-        randomModel.execute_batch(builtQueries, function(err){
-            if(err) callback(err);
-            else callback();
+CassandraClient.uuidFromString = function (string) {
+    return cql.types.Uuid.fromString(string);
+};
+
+CassandraClient.prototype.doBatch = function (queries, callback) {
+    var randomModel = this.modelInstance[Object.keys(this.modelInstance)[0]];
+    var builtQueries = [];
+    for(var i=0;i<queries.length;i++) {
+        builtQueries.push({
+            query: queries[i],
+            params: []
         });
     }
-
-    static doBatch(queries, callback) {
-        CassandraClient.prototype.doBatch.call(CassandraClient, queries, callback);
-    }
-
-    static get consistencies() {
-        return cql.types.consistencies;
-    }
-
-    static get datatypes() {
-        return cql.types;
-    }
-
-    static maxTimeuuid(date) {
-        return CassandraClient.timeuuid(date, "max");
-    }
-
-    static minTimeuuid(date) {
-        return CassandraClient.timeuuid(date, "min");
-    }
-
-    static get instance() {
-        return CassandraClient.modelInstance;
-    }
-
-    static get close() {
-        return CassandraClient.orm.close;
-    }
-
-    maxTimeuuid(date) {
-        return this.timeuuid(date, "max");
-    }
-
-    minTimeuuid(date) {
-        return this.timeuuid(date, "min");
-    }
-
-    get instance() {
-        return this.modelInstance;
-    }
-
-    get close() {
-        return this.orm.close;
-    }
-
-    static _translateFileNameToModelName (fileName) {
-        return fileName
-            .slice(	0,
-                    //Get everything before the last dot
-                    fileName.lastIndexOf('.'))
-            .replace('Model', '');
-    }
+    randomModel.execute_batch(builtQueries, function(err){
+        if(err) callback(err);
+        else callback();
+    });
 };
+
+CassandraClient.doBatch = function (queries, callback) {
+    CassandraClient.prototype.doBatch.call(CassandraClient, queries, callback);
+};
+
+CassandraClient.maxTimeuuid = function (date) {
+    return CassandraClient.timeuuid(date, "max");
+};
+
+CassandraClient.minTimeuuid = function (date) {
+    return CassandraClient.timeuuid(date, "min");
+};
+
+CassandraClient.prototype.maxTimeuuid = function (date) {
+    return this.timeuuid(date, "max");
+};
+
+CassandraClient.prototype.minTimeuuid = function (date) {
+    return this.timeuuid(date, "min");
+};
+
+
+CassandraClient._translateFileNameToModelName = function (fileName) {
+    return fileName
+        .slice(	0,
+                //Get everything before the last dot
+                fileName.lastIndexOf('.'))
+        .replace('Model', '');
+};
+
+
+Object.defineProperties(CassandraClient, {
+    consistencies: {
+        get: function () {
+            return cql.types.consistencies;
+        }
+    },
+    datatypes: {
+        get: function () {
+            return cql.types;
+        }
+    },
+    instance: {
+        get: function () {
+            return CassandraClient.modelInstance;
+        }
+    },
+    close: {
+        get: function () {
+            return CassandraClient.orm.close;
+        }
+    }
+});
+
+
+Object.defineProperties(CassandraClient.prototype, {
+    consistencies: {
+        get: function () {
+            return cql.types.consistencies;
+        }
+    },
+    datatypes: {
+        get: function () {
+            return cql.types;
+        }
+    },
+    instance: {
+        get: function () {
+            return this.modelInstance;
+        }
+    },
+    close: {
+        get: function () {
+            return this.orm.close;
+        }
+    }
+});
+
+
 
 CassandraClient.prototype.uuid = CassandraClient.uuid;
 CassandraClient.prototype.uuidFromString = CassandraClient.uuidFromString;
 CassandraClient.prototype.timeuuid = CassandraClient.timeuuid;
-CassandraClient.prototype.consistencies = CassandraClient.consistencies;
-CassandraClient.prototype.datatypes = CassandraClient.datatypes;
 CassandraClient.prototype._translateFileNameToModelName = CassandraClient._translateFileNameToModelName;
 
 module.exports = CassandraClient;


### PR DESCRIPTION
Let me know if I can change anything, these improvements should be backwards compatible.
- create an instance of the `express-cassandra` object for multiple connections 
- expose method to load schemas arbitrarily