### PR TITLE
Custom Cassandra UDT support capability

### DIFF
--- a/lib/orm/apollo_schemer.js
+++ b/lib/orm/apollo_schemer.js
@@ -41,7 +41,7 @@ var schemer = {
                     output_schema.fields[k].typeDef = "<" + model_schema.typeMaps[k].toString() + ">";
                 }
                 else {
-                    output_schema.fields[k].typeDef = "<" + output_schema.fields[k].typeDef.replace(/[\s\<\>]/g,'').replace(/varchar/g,'text').split(',').toString() + ">";
+                    output_schema.fields[k].typeDef = output_schema.fields[k].typeDef.replace(/[\s]/g,'').replace(/varchar/g,'text').split(',').toString();
                 }
             }
         }

--- a/lib/orm/base_model.js
+++ b/lib/orm/base_model.js
@@ -727,8 +727,32 @@ BaseModel._get_db_value_expression = function(fieldname, fieldvalue){
                 else if(fieldvalue[key] instanceof Date) {
                     retvallist += "'"+ fieldvalue[key].toISOString().slice(0,-5).replace('T',' ') + '+0000' +"',";
                 }
+                else if(typeof fieldvalue[key] === "object"){
+
+                    var str = '{';
+                    for(var p in fieldvalue[key]){
+                        if(typeof fieldvalue[key][p] === 'string'){
+                            str += p + ":'" + fieldvalue[key][p] + "'" +",";;
+                        }
+                        else if(typeof fieldvalue[key][p] === 'number'){
+                             str += p + ":" + fieldvalue[key][p] +",";
+                        }
+                        else if(typeof fieldvalue[key][p] === 'boolean'){       
+                             str += p + ":" + fieldvalue[key][p] +",";
+                        }
+                        else{
+                            str += p + ":'" + fieldvalue[key][p] + "'" +",";;
+                        }                      
+                    }
+                    str = str.substring(0, str.length - 1);
+                    str += '}'
+
+                    //var JSONstring = fieldvalue[key];
+                    retvallist +=  str +",";
+                }
                 else {
-                    retvallist += fieldvalue[key].toString()+",";
+                    var JSONstring = fieldvalue[key].toString();
+                    retvallist +=  JSONstring +",";
                 }
             }
             //remove the final comma

--- a/lib/orm/cassandra_types.js
+++ b/lib/orm/cassandra_types.js
@@ -126,6 +126,12 @@ TYPE_MAP.extract_typeMap = function(val){
         }
     }
 
+    if(typeMaps.length ==0 && val.indexOf('list')> -1){
+        var tm = decomposed[1] + '<' + decomposed[2] +'>';
+        typeMaps.push(tm);
+    }
+
+
     return typeMaps;
 };
 


### PR DESCRIPTION
When a custom UDT is predefined in a database such as 

```
CREATE TYPE custom_revenue (
    amount float,
    date timestamp
  );
```

and a table should exist using the custom UDT such as

```
CREATE TABLE sample (
    id text PRIMARY KEY,
    revenue list<frozen<custom_revenue>>
  );
```
a model for the table should be able to be defined such as

```
module.exports = {
  "fields": {
    "id" : {
      "type" : "varchar"
    },
    "revenue" : {
      "type" : "list",
      "typeDef" : "<frozen <custom_revenue>>",
      "default" : null
    }
  },
  "key":["id"]
}
```

The current express-cassandra code base will fail on this situation as it does not recognize UDT's. The table will be created if it doesn't exist but the next call will fail as it will see the schema as changed.  We have made a few minor bug fixes to your code base that then allows this use case to work properly.  It would be great if you see it appropriate to take in the few changes we have suggested so that this use case would work properly.