### PR TITLE
 loadSchema callback fix

### DIFF
--- a/src/expressCassandra.js
+++ b/src/expressCassandra.js
@@ -88,19 +88,14 @@ CassandraClient.prototype.connect = function f(callback) {
 
 CassandraClient.prototype.loadSchema = function f(modelName, modelSchema, callback) {
   const self = this;
-  const cb = (err) => {
-    if (err) {
-      callback(err);
-      return;
+  const cb = cb(err) => {
+    if(typeof callback === 'function') {
+      err ? callback(err): callback(null, self.modelInstance[modelName]);
     }
-    callback(null, self.modelInstance[modelName]);
   };
-  self.modelInstance[modelName] = self.orm.add_model(
-    modelName,
-    modelSchema,
-    cb
-  );
+  self.modelInstance[modelName] = self.orm.add_model(modelName, modelSchema, cb);
   self.modelInstance[modelName] = Promise.promisifyAll(self.modelInstance[modelName]);
+  return self.modelInstance[modelName];
 };
 
 CassandraClient.uuid = () => (cql.types.Uuid.random());

--- a/src/expressCassandra.js
+++ b/src/expressCassandra.js
@@ -88,7 +88,7 @@ CassandraClient.prototype.connect = function f(callback) {
 
 CassandraClient.prototype.loadSchema = function f(modelName, modelSchema, callback) {
   const self = this;
-  const cb = cb(err) => {
+  const cb = function(err) {
     if(typeof callback === 'function') {
       err ? callback(err): callback(null, self.modelInstance[modelName]);
     }

--- a/src/expressCassandra.js
+++ b/src/expressCassandra.js
@@ -88,9 +88,10 @@ CassandraClient.prototype.connect = function f(callback) {
 
 CassandraClient.prototype.loadSchema = function f(modelName, modelSchema, callback) {
   const self = this;
-  const cb = function(err) {
-    if(typeof callback === 'function') {
-      err ? callback(err): callback(null, self.modelInstance[modelName]);
+  const cb = function cb(err) {
+    if (typeof callback === 'function') {
+      if (err) callback(err);
+      else callback(null, self.modelInstance[modelName]);
     }
   };
   self.modelInstance[modelName] = self.orm.add_model(modelName, modelSchema, cb);


### PR DESCRIPTION
 First of all :+1:  for providing promise support.

One issue which I have been facing is that LoadSchema function should return modelInstance object. Also passing callback function should be optional. 

I have fixed it similar to apollo's add_model(_generate_model) function. 

`Model._set_properties(properties);`
    
`Model.syncDefinition(function (err, result) `
 `     if (typeof callback === 'function') {`
`        if (err) callback(err);else callback(null, result);
`      }
    `});`
`return Model
`

Please review.