### PR TITLE
Add isModified model method

### DIFF
--- a/docs/datatypes.md
+++ b/docs/datatypes.md
@@ -7,11 +7,13 @@ Express cassandra exposes some node driver methods for convenience. To generate 
 *   `models.uuid()`
     returns a version 4 (random) uuid as javascript type models.datatypes.Uuid, suitable for Cassandra `uuid` fields.
 *   `models.uuidFromString(str)`
-    returns a version 4 uuid as javascript type models.datatypes.Uuid from input string, suitable for Cassandra `uuid` fields
-*   `models.timeuuid() / models.timeuuidFromString(str)`
-    returns a version 1 (time-based) uuid as javascript type models.datatypes.TimeUuid, suitable for Cassandra `timeuuid` fields. Parameter str should be a valid timeuuid string.
-*   `models.timeuuidFromDate(date) / .maxTimeuuid(date) / .minTimeuuid(date)`
-    returns a version 1 (time-based) uuid as javascript type models.datatypes.TimeUuid, suitable for Cassandra `timeuuid` fields. Parameter `date` should be a javascript Date object. From the [Datastax documentation](https://docs.datastax.com/en/cql/3.3/cql/cql_reference/timeuuid_functions_r.html):
+    returns a version 4 uuid as javascript type models.datatypes.Uuid from input string, suitable for Cassandra `uuid` fields.
+*   `models.uuidFromBuffer(buf)`
+    returns a version 4 uuid as javascript type models.datatypes.Uuid from input buffer, suitable for Cassandra `uuid` fields. Parameter buf must be a 16-byte buffer.
+*   `models.timeuuid() / models.timeuuidFromString(str) / models.timeuuidFromBuffer(buf)`
+    returns a version 1 (time-based) uuid as javascript type models.datatypes.TimeUuid, suitable for Cassandra `timeuuid` fields. Parameter str must be a valid timeuuid string. Parameter buf must be a 16-byte buffer.
+*   `models.timeuuidFromDate(date) / models.maxTimeuuid(date) / models.minTimeuuid(date)`
+    returns a version 1 (time-based) uuid as javascript type models.datatypes.TimeUuid, suitable for Cassandra `timeuuid` fields. Parameter `date` must be a javascript Date object. From the [Datastax documentation](https://docs.datastax.com/en/cql/3.3/cql/cql_reference/timeuuid_functions_r.html):
 
     > The min/maxTimeuuid example selects all rows where the timeuuid column, t, is strictly later than 2013-01-01 00:05+0000 but strictly earlier than 2013-02-02 10:00+0000. The t >= maxTimeuuid('2013-01-01 00:05+0000') does not select a timeuuid generated exactly at 2013-01-01 00:05+0000 and is essentially equivalent to t > maxTimeuuid('2013-01-01 00:05+0000').
 

--- a/docs/management.md
+++ b/docs/management.md
@@ -180,3 +180,29 @@ module.exports = {
 * `before_delete` if defined, will be automatically called each time before a delete operation is performed. The `queryObject` will contain the query part of the delete operation as is, so you could modify them if required or perform other things based on them. The `options` will contain the query options being passed to cassandra. You could also modify the options or do things based on it. The `next` is a callback function and after you're done, you must call it like `next()` to let the data deleted in cassandra. Otherwise you may also send an error message like `next(err)` to halt the delete operation. In this case the data will not be deleted and the caller will receive the error message via callback.
 
 * `after_delete` if defined, will be automatically called each time after a delete operation is successfully performed. The `queryObject` will contain the query part of the delete operation as is, so you could get the query that was actually used and perform other things based on it. The `options` will contain the final query options passed to cassandra. The `next` is a callback function and after you're done, you must call it like `next()` to let the caller recieve it's callback. Otherwise you may also send an error message like `next(err)` and in this case the caller will receive the error message via callback.
+
+## Tracking changes to data
+
+The isModified operation on a model instance lets you know whether or not the entire document or a field in particular has been modified locally since it has been retrieved from the database. This can be useful if you are running expensive operations in your model hooks that do not need to be performed in case the value of a field has not changed.
+
+```js
+var john = new models.instance.Person({name: 'John', surname: 'Doe', age: 32});
+john.isModified(); // Returns true
+john.save(function(err){
+    if(err) console.log(err);
+    john.isModified(); // Returns false
+});
+
+var jane = models.instance.Person.findOne({name: 'Jane'}, (err, jane) => {
+  if(err) throw err;
+  if(jane){
+    jane.isModified('surname'); // Returns false
+    jane.surname = 'Smith';
+    jane.isModified('surname'); // Returns true
+    jane.save((err) => {
+        if(err) console.log(err);
+        jane.isModified('surname'); // Returns false
+    });
+  });
+});
+```

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -16,6 +16,7 @@ module.exports = {
                 return this.name + ' ' + this.surname;
             }
         },
+        password_hash: "blob",
         age: "int",
         active: "boolean",
         created: {
@@ -46,7 +47,12 @@ module.exports = {
     ],
     table_name: "my_custom_table_name",
     methods: {
-        myCustomMethod: function () {
+        setPassword: function (password, callback) {
+          crypto.pbkdf2Sync('secret', 'salt', 100000, 512, 'sha512', (err, hashed) => {
+            if (err) { return callback(err); }
+            this.password_hash = hashed;
+            return callback();
+          });
         }
     }
 }
@@ -85,7 +91,7 @@ What does the above code means?
 
 - `table_name` provides the ability to use a different name for the actual table in cassandra. By default the lowercased modelname is used as the table name. But if you want a different table name instead, then you may want to use this optional field to specify the custom name for your cassandra table.
 
-- `methods` allows you to define custom methods for your instances.
+- `methods` allows you to define custom methods for your instances. This can be useful when a single model method should act on various fields and therefore cannot be mapped to a virtual field, or when an asynchronous operation is required for reading or updating a field, such as hashing a password or retrieving related data against a database.
 
 When you instantiate a model, every field you defined in schema is automatically a property of your instances. So, you can write:
 

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -44,7 +44,11 @@ module.exports = {
             options: {}
         }
     ],
-    table_name: "my_custom_table_name"
+    table_name: "my_custom_table_name",
+    methods: {
+        myCustomMethod: function () {
+        }
+    }
 }
 
 ```
@@ -80,6 +84,8 @@ What does the above code means?
 - `custom_indexes` is an array of objects defining the custom indexes for the table. The `on` section should contain the column name on which the index should be built, the `using` section should contain the custom indexer class path and the `options` section should contain the passed options for the indexer class if any. If no `options` are required, pass a blank {} object.
 
 - `table_name` provides the ability to use a different name for the actual table in cassandra. By default the lowercased modelname is used as the table name. But if you want a different table name instead, then you may want to use this optional field to specify the custom name for your cassandra table.
+
+- `methods` allows you to define custom methods for your instances.
 
 When you instantiate a model, every field you defined in schema is automatically a property of your instances. So, you can write:
 

--- a/src/expressCassandra.js
+++ b/src/expressCassandra.js
@@ -115,11 +115,15 @@ CassandraClient.uuid = () => (cql.types.Uuid.random());
 
 CassandraClient.uuidFromString = (str) => (cql.types.Uuid.fromString(str));
 
+CassandraClient.uuidFromBuffer = (buf) => (new cql.types.Uuid(buf));
+
 CassandraClient.timeuuid = () => (cql.types.TimeUuid.now());
 
 CassandraClient.timeuuidFromDate = (date) => (cql.types.TimeUuid.fromDate(date));
 
 CassandraClient.timeuuidFromString = (str) => (cql.types.TimeUuid.fromString(str));
+
+CassandraClient.timeuuidFromBuffer = (buf) => (new cql.types.TimeUuid(buf));
 
 CassandraClient.maxTimeuuid = (date) => (cql.types.TimeUuid.max(date));
 
@@ -272,9 +276,11 @@ Object.defineProperties(CassandraClient.prototype, {
 
 CassandraClient.prototype.uuid = CassandraClient.uuid;
 CassandraClient.prototype.uuidFromString = CassandraClient.uuidFromString;
+CassandraClient.prototype.uuidFromBuffer = CassandraClient.uuidFromBuffer;
 CassandraClient.prototype.timeuuid = CassandraClient.timeuuid;
 CassandraClient.prototype.timeuuidFromDate = CassandraClient.timeuuidFromDate;
 CassandraClient.prototype.timeuuidFromString = CassandraClient.timeuuidFromString;
+CassandraClient.prototype.timeuuidFromBuffer = CassandraClient.timeuuidFromBuffer;
 CassandraClient.prototype.maxTimeuuid = CassandraClient.maxTimeuuid;
 CassandraClient.prototype.minTimeuuid = CassandraClient.minTimeuuid;
 

--- a/src/orm/base_model.js
+++ b/src/orm/base_model.js
@@ -18,6 +18,7 @@ const BaseModel = function f(instanceValues) {
   instanceValues = instanceValues || {};
   const fieldValues = {};
   const fields = this.constructor._properties.schema.fields;
+  const methods = this.constructor._properties.schema.methods || {};
   const model = this;
 
   const defaultSetter = function f1(propName, newValue) {
@@ -61,6 +62,12 @@ const BaseModel = function f(instanceValues) {
     if (!field.virtual) {
       this[propertyName] = instanceValues[propertyName];
     }
+  }
+
+  for (let methodNames = Object.keys(methods), i = 0, len = methodNames.length; i < len; i++) {
+    const methodName = methodNames[i];
+    const method = methods[methodName];
+    this[methodName] = method;
   }
 };
 

--- a/src/orm/base_model.js
+++ b/src/orm/base_model.js
@@ -1939,8 +1939,8 @@ BaseModel.update = function f(queryObject, updateValues, options, callback) {
     return {
       query,
       params: queryParams,
-      before_hook: hookRunner(schema.before_update, 'model.update.before.error');
-      after_hook: hookRunner(schema.after_update, 'model.update.after.error');
+      before_hook: hookRunner(schema.before_update, 'model.update.before.error'),
+      after_hook: hookRunner(schema.after_update, 'model.update.after.error'),
     };
   }
 

--- a/src/orm/base_model.js
+++ b/src/orm/base_model.js
@@ -1923,29 +1923,24 @@ BaseModel.update = function f(queryObject, updateValues, options, callback) {
     };
   }
 
+  function hookRunner(fn, errorCode) {
+    return (hookCallback) => {
+      fn(queryObject, updateValues, options, (error) => {
+        if (error) {
+          hookCallback(buildError(errorCode, error));
+          return;
+        }
+        hookCallback();
+      });
+    };
+  }
+
   if (options.return_query) {
     return {
       query,
       params: queryParams,
-      before_hook: (hookCallback) => {
-        schema.before_update(queryObject, updateValues, options, (error) => {
-          if (error) {
-            hookCallback(buildError('model.update.before.error', error));
-            return;
-          }
-          hookCallback();
-        });
-      },
-      after_hook: (hookCallback) => {
-        queryObject._modified = {};
-        schema.after_update(queryObject, updateValues, options, (error) => {
-          if (error) {
-            hookCallback(buildError('model.update.after.error', error));
-            return;
-          }
-          hookCallback();
-        });
-      },
+      before_hook: hookRunner(schema.before_update, 'model.update.before.error');
+      after_hook: hookRunner(schema.after_update, 'model.update.after.error');
     };
   }
 

--- a/test/models/PersonModel.js
+++ b/test/models/PersonModel.js
@@ -147,8 +147,8 @@ module.exports = {
     next();
   },
   methods: {
-    getName: () => {
+    getName: function getName() {
       return this.Name;
-    }
-  }
+    },
+  },
 };

--- a/test/models/PersonModel.js
+++ b/test/models/PersonModel.js
@@ -147,7 +147,7 @@ module.exports = {
     next();
   },
   methods: {
-    getName: function() {
+    getName: () => {
       return this.Name;
     }
   }

--- a/test/models/PersonModel.js
+++ b/test/models/PersonModel.js
@@ -146,4 +146,9 @@ module.exports = {
   after_delete: (queryObject, options, next) => {
     next();
   },
+  methods: {
+    getName: function() {
+      return this.Name;
+    }
+  }
 };

--- a/test/test.js
+++ b/test/test.js
@@ -400,6 +400,7 @@ describe('Unit Tests', () => {
         person.isModified().should.equal(false);
         person.Name = 'john';
         person.isModified('Name').should.equal(true);
+        person.isModified('age').should.equal(false);
         person.isModified().should.equal(true);
         person.getName().should.equal('john');
         done();

--- a/test/test.js
+++ b/test/test.js
@@ -401,6 +401,7 @@ describe('Unit Tests', () => {
         person.Name = 'john';
         person.isModified('Name').should.equal(true);
         person.isModified().should.equal(true);
+        person.getName().should.equal('john');
         done();
       });
     });

--- a/test/test.js
+++ b/test/test.js
@@ -316,16 +316,26 @@ describe('Unit Tests', () => {
         },
         active: true,
       });
+      alex.isModified().should.equal(true);
+      alex.isModified('userID').should.equal(true);
+      alex.isModified('address').should.equal(true);
+      alex.isModified('someNonExistingField').should.equal(false);
       alex.save((err) => {
         if (err) {
           err.name.should.equal('apollo.model.validator.invalidvalue');
           alex.age = 32;
+          alex.isModified().should.equal(true);
+          alex.isModified('userID').should.equal(true);
+          alex.isModified('address').should.equal(true);
           alex.save((err1) => {
             if (err1) {
               err1.name.should.equal('apollo.model.save.unsetrequired');
               alex.points = 64.0;
               alex.saveAsync()
                 .then(() => {
+                  alex.isModified().should.equal(false);
+                  alex.isModified('userID').should.equal(false);
+                  alex.isModified('address').should.equal(false);
                   done();
                 })
                 .catch((err2) => {
@@ -387,6 +397,10 @@ describe('Unit Tests', () => {
         person.intMapDefault.should.deep.equal({ one: 1, two: 2 });
         person.stringListDefault.should.have.members(['one', 'two']);
         person.intSetDefault.should.have.members([1, 2]);
+        person.isModified().should.equal(false);
+        person.Name = 'john';
+        person.isModified('Name').should.equal(true);
+        person.isModified().should.equal(true);
         done();
       });
     });


### PR DESCRIPTION
The goal is to mimic the behavior of the `isModified()` model method of Mongoose [1].
Such method can be used, for example to perform expensive validation in pre_save hooks without having to revalidate non-modified fields.

Tests have been updated accordingly.

[1] [http://mongoosejs.com/docs/3.0.x/docs/api.html#document_Document-isModified](http://mongoosejs.com/docs/3.0.x/docs/api.html#document_Document-isModified)