### PR TITLE
Check for key/value equality when altering UDT

### DIFF
--- a/src/orm/apollo.js
+++ b/src/orm/apollo.js
@@ -207,8 +207,7 @@ Apollo.prototype = {
                 fieldTypes[i] = util.format('frozen<%s>', fieldTypes[i]);
               }
             }
-
-            if (_.isEqual(udtKeys, fieldNames) && _.isEqual(udtValues, fieldTypes)) {
+            if (_.difference(udtKeys, fieldNames).length === 0 && _.difference(udtValues, fieldTypes).length === 0) {
               udtCallback();
             } else {
               throw (new Error(


### PR DESCRIPTION
Compare existing UDT keys/values against altered UDT keys/values for equality without considering order of keys/values. Fixes #120 