### PR TITLE
Fixed the fieldObject.type reference with fieldtype in validate_field().

### DIFF
--- a/src/validators/schema.js
+++ b/src/validators/schema.js
@@ -34,18 +34,18 @@ const schemer = {
     }
     const fieldtype = this.get_field_type(modelSchema, fieldName);
     if (!_.has(datatypes, fieldtype)) {
-      throw (new Error(util.format('Invalid field type "%s" for field: %s', fieldObject.type, fieldName)));
+      throw (new Error(util.format('Invalid field type "%s" for field: %s', fieldtype, fieldName)));
     }
-    if (['map', 'list', 'set', 'frozen'].includes(fieldObject.type)) {
+    if (['map', 'list', 'set', 'frozen'].includes(fieldtype)) {
       if (!fieldObject.typeDef) {
-        throw (new Error(util.format('Missing typeDef for field type "%s" on field: %s', fieldObject.type, fieldName)));
+        throw (new Error(util.format('Missing typeDef for field type "%s" on field: %s', fieldtype, fieldName)));
       }
       if (typeof fieldObject.typeDef !== 'string') {
-        throw (new Error(util.format('Invalid typeDef for field type "%s" on field: %s', fieldObject.type, fieldName)));
+        throw (new Error(util.format('Invalid typeDef for field type "%s" on field: %s', fieldtype, fieldName)));
       }
     }
     if (!(this.is_field_default_value_valid(modelSchema, fieldName))) {
-      throw (new Error(util.format('Invalid defult value for field: %s(%s)', fieldName, fieldObject.type)));
+      throw (new Error(util.format('Invalid defult value for field: %s(%s)', fieldName, fieldtype)));
     }
   },
 


### PR DESCRIPTION
I decided to try to create a Pull request, So I'll close #182

I'm starting with express-cassandra and I got the following error

> (node:13187) UnhandledPromiseRejectionWarning: apollo.model.validator.invalidschema: Invalid field type "undefined" for field: content_id

Looking at the code I see that the type can either be a field or a string;

    get_field_type(modelSchema, fieldName) {
      var fieldObject = modelSchema.fields[fieldName];

      if (typeof fieldObject === 'string') {
        return fieldObject;
      }
      if (_.isPlainObject(fieldObject)) {
        return fieldObject.type;
      }
      throw new Error('Field type not defined properly');
    },

However, in the code generating the error:

    var fieldtype = this.get_field_type(modelSchema, fieldName);
    if (!_.has(datatypes, fieldtype)) {
      throw new Error(util.format('Invalid field type "%s" for field: %s', fieldObject.type, fieldName));
    }

I suggest changing the `fieldObject.type` with `fieldtype` as follow:

      throw new Error(util.format('Invalid field type "%s" for field: %s', fieldtype, fieldName));

Then I can see that it's not happen with 'long' as a field type:

> (node:13187) UnhandledPromiseRejectionWarning: apollo.model.validator.invalidschema: Invalid field type "long" for field: content_id

Which is strange, but at least makes a lot more sense.