### PR TITLE
Tell the developer which field has an invalid type.

### DIFF
--- a/src/validators/schema.js
+++ b/src/validators/schema.js
@@ -391,7 +391,7 @@ const schemer = {
     if (_.isPlainObject(fieldObject)) {
       return fieldObject.type;
     }
-    throw (new Error('Field type not defined properly'));
+    throw (new Error('Type of field "' + fieldName + '" not defined properly'));
   },
 
   is_required_field(modelSchema, fieldName) {


### PR DESCRIPTION
I wanted to make sure that the consistency could be specify in a query so I used:

    let result = model.find({
        consistency: 'broken',
        ....
    })

knowing that should not work and got that error saying there is a problem but really unhelpful if I were to add many fields all at the same time. Lucky for me, I knew exactly which field was wrong! Anyway, I think it's much better to let the developer know which field the system is not happy about.