### PR TITLE
fix: Adds support to export.default from es6 models definitions

### DIFF
--- a/src/expressCassandra.js
+++ b/src/expressCassandra.js
@@ -49,7 +49,8 @@ CassandraClient.syncModelFileToDB = (file, callback) => {
   if (modelName) {
     const fileLocation = path.join(CassandraClient.directory, file.path);
     // eslint-disable-next-line import/no-dynamic-require
-    const modelSchema = require(fileLocation);
+    const defaultModelSchema = require(fileLocation);
+    const modelSchema = defaultModelSchema.default ? defaultModelSchema.default : defaultModelSchema;
     CassandraClient.modelInstance[modelName] = CassandraClient.orm.addModel(modelName.toLowerCase(), modelSchema);
     CassandraClient.modelInstance[modelName].syncDB(callback);
     CassandraClient.modelInstance[modelName] = Promise.promisifyAll(CassandraClient.modelInstance[modelName]);


### PR DESCRIPTION
### WHY are these changes introduced?

Currently, the package allows to define models only for `es5` modules:
```js
module.exports = {
    fields:{
        name    : "text",
        surname : "text",
        age     : "int",
        created : "timestamp"
    },
    key:["name"]
}
```
Need to support `es6` usage as well:
```js
exports default {
    fields:{
        name    : "text",
        surname : "text",
        age     : "int",
        created : "timestamp"
    },
    key:["name"]
}
```
This means that now models can be written on typescript and transpiled to js, 
```js
Object.defineProperty(exports, "__esModule", { value: true });
exports.default = {
    fields:{
        name    : "text",
        surname : "text",
        age     : "int",
        created : "timestamp"
    },
    key:["name"]
};
```

When the package tries to load models like the last one, fields cannot be found because is one level deep than expected and the following error will be displayed:
`Unhandled rejection apollo.model.validator.invalidschema: Schema must contain a non-empty "fields" map object`

### WHAT is this pull request doing?
Adds support to es6 models definition by setting the `modelSchema` at the expected level.