### PR TITLE
Scylla Materialize View Drop

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express-cassandra",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "dependencies": {
     "JSONStream": "^1.3.1",
     "async": "^1.5.2",

--- a/src/builders/table.js
+++ b/src/builders/table.js
@@ -512,7 +512,7 @@ TableBuilder.prototype = {
       (viewName) => (!_.isEqual(
         normalizedDBSchema.materialized_views[viewName],
         normalizedModelSchema.materialized_views[viewName],
-      )),
+      )) && !viewName.includes("idx_index"),
     );
 
     const addedMaterializedViews = {};

--- a/src/builders/table.js
+++ b/src/builders/table.js
@@ -515,6 +515,7 @@ TableBuilder.prototype = {
       )) && !viewName.includes("idx_index"),
     );
 
+    
     const addedMaterializedViews = {};
     addedMaterializedViewsNames.forEach((viewName) => {
       addedMaterializedViews[viewName] = normalizedModelSchema.materialized_views[viewName];


### PR DESCRIPTION
in scylla, every index will create materialized view. when migration proses, all materialize view will be drop include index. so, i make filter to delete just pure materialize view only, and exclude materialize view which created by index.