### PR TITLE
fix: support .cjs extension for use in esm module

### DIFF
--- a/src/expressCassandra.js
+++ b/src/expressCassandra.js
@@ -70,7 +70,8 @@ CassandraClient.bind = (options, cb) => {
       fileFilter: [
         '*.js', '*.javascript', '*.jsx', '*.coffee', '*.coffeescript', '*.iced',
         '*.script', '*.ts', '*.tsx', '*.typescript', '*.cjsx', '*.co', '*.json',
-        '*.json5', '*.litcoffee', '*.liticed', '*.ls', '*.node', '*.toml', '*.wisp',
+        '*.json5', '*.litcoffee', '*.liticed', '*.ls', '*.node', '*.toml',
+        '*.wisp', '*.cjs',
       ],
     }))
     .then((fileList) => {


### PR DESCRIPTION
If the model extension is `.js` and a esm module uses express-cassandra  you get the following error in node v14.19.3:

```
require() of FooModel.js from /home/face/proj/test/test-api/node_modules/express-cassandra/lib/expressCassandra.js is an ES module file as it is a .js file whose nearest parent package.json contains "type": "module" which defines all .js files in that package scope as ES modules.
Instead rename CommentsModel.js to end in .cjs, change the requiring code to use import(), or remove "type": "module" from /home/face/proj/test/test-api/package.json.
```

This adds `.cjs` to the file filter so express-cassandra can then use `require()` on your models using the `.cjs` file extension.
