### PR TITLE
fix: where clause comparison in schema match

### DIFF
--- a/src/utils/normalizer.js
+++ b/src/utils/normalizer.js
@@ -160,6 +160,9 @@ const normalizer = {
 
       if (!outputMView.where_clause) {
         outputMView.where_clause = parser.get_mview_where_clause(outputSchema, outputMView).trim();
+      } else {
+        // some versions of cassandra/scylla return IS NOT null instead of IS NOT NULL
+        outputMView.where_clause = outputMView.where_clause.replace(/IS NOT null/g, 'IS NOT NULL');
       }
       if (_.isPlainObject(outputMView.filters)) {
         delete outputMView.filters;


### PR DESCRIPTION
This PR fixes a bug with certain versions of cassandra/scylla where the "where clause" is incorrectly compared in the schema validation because it has mismatching cases for "null". Sometimes it's "IS NOT NULL" and sometimes it's "IS NOT null".