### PR TITLE
add 'error' handler on stream event emitter.

### DIFF
--- a/src/helpers/driver.js
+++ b/src/helpers/driver.js
@@ -96,7 +96,7 @@ Driver.prototype = {
         return;
       }
       debug('executing stream query: %s with params: %j', query, params);
-      this._properties.cql.stream(query, params, options).on('readable', onReadable).on('end', callback);
+      this._properties.cql.stream(query, params, options).on('readable', onReadable).on('end', callback).on('error', callback);
     });
   },
 };


### PR DESCRIPTION
If 'error' events are not handled, Node.js crashes. So adding the event handler here to propagate up the error.

Feedback is welcome.

Please note that I didn't run the test harness. If this change looks reasonable, I can invest in setting up a local dev environment for this project and run the tests.

closes: #273